### PR TITLE
change logger

### DIFF
--- a/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/issues/client/Issue5_DiscardedClientRequestNotGenerated.scala
+++ b/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/issues/client/Issue5_DiscardedClientRequestNotGenerated.scala
@@ -50,7 +50,7 @@ class DiscardedClientRequestNotGeneratedSpec extends Specification with NoTimeCo
     """
 akka {
       loglevel = DEBUG
-      loggers = ["akka.event.slf4j.Slf4jLogger"]
+      loggers = ["akka.testkit.TestEventListener"]
       log-dead-letters-during-shutdown=off
             log-config-on-start = off
             # event-stream = on


### PR DESCRIPTION
In order to see your logging while running in test mode you need to set the logger to:
"akka.testkit.TestEventListener"
