### PR TITLE
Pass on spray HttpClientConnection errors

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -5,8 +5,8 @@ object Common {
 
   val settings: Seq[Setting[_]] = Seq (
     organization := "com.pragmasoft",
-    version := "1.1-spray1.3",
-    scalaVersion := "2.10.3",
+    version := "1.2-spray1.3",
+    scalaVersion := "2.11.7",
     crossScalaVersions := Seq("2.11.0"),
     licenses += ("Apache-2.0", url("https://opensource.org/licenses/Apache-2.0"))
   )
@@ -16,7 +16,7 @@ object Common {
   val akkaVersion = "2.3.2"
 
   def testDependencies(scala_version: String) = Seq(
-    "org.specs2" %%  "specs2" % "2.3.12" % "test",
+    "org.specs2" %%  "specs2" % "2.5" % "test",
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
     "org.mockito" % "mockito-all" % "1.9.5" % "test",
 
@@ -24,6 +24,8 @@ object Common {
     "org.slf4j" % "slf4j-api" % sl4jVersion % "test",
     "org.slf4j" % "slf4j-jcl" % sl4jVersion % "test",
     "org.slf4j" % "slf4j-log4j12" % "1.7.5" % "test",
+    "org.scalaz.stream" % "scalaz-stream_2.11" % "0.7.2a" % "test",
+
 
     "io.spray" %% "spray-routing" % sprayImportVersion(scala_version) % "test"
   )

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -24,7 +24,7 @@ object Common {
     "org.slf4j" % "slf4j-api" % sl4jVersion % "test",
     "org.slf4j" % "slf4j-jcl" % sl4jVersion % "test",
     "org.slf4j" % "slf4j-log4j12" % "1.7.5" % "test",
-    "org.scalaz.stream" % "scalaz-stream_2.11" % "0.7.2a" % "test",
+    "org.scalaz.stream" %% "scalaz-stream" % "0.7.2a" % "test",
 
 
     "io.spray" %% "spray-routing" % sprayImportVersion(scala_version) % "test"

--- a/spray-funnel/src/main/scala/com/pragmasoft/reactive/throttling/http/server/HttpServerThrottlingCoordinator.scala
+++ b/spray-funnel/src/main/scala/com/pragmasoft/reactive/throttling/http/server/HttpServerThrottlingCoordinator.scala
@@ -1,31 +1,14 @@
 package com.pragmasoft.reactive.throttling.http.server
 
-import akka.actor.{ActorSystem, ActorRefFactory, Props, ActorRef}
-import com.pragmasoft.reactive.throttling.threshold.Frequency
-import com.pragmasoft.reactive.throttling.actors._
-import spray.http._
-import com.pragmasoft.reactive.throttling.actors.handlerspool.{OneActorPerRequestPool, FixedSizePool, HandlerFactory}
-import scala.concurrent.ExecutionContext
+import akka.actor._
 import akka.util.Timeout
-import akka.io
-import spray.can.Http
-import spray.util._
-import scala.concurrent.duration._
-import com.pragmasoft.reactive.throttling.threshold.Frequency
-import scala.reflect.ManifestFactory
-import com.pragmasoft.reactive.throttling.http._
-import DiscardReason._
-import com.pragmasoft.reactive.throttling.http.DiscardReason
-import com.pragmasoft.reactive.throttling.actors.ClientRequest
-import com.pragmasoft.reactive.throttling.http.FailedClientRequest
-import com.pragmasoft.reactive.throttling.threshold.Frequency
-import com.pragmasoft.reactive.throttling.http.DiscardedClientRequest
-import spray.http.HttpRequest
-import com.pragmasoft.reactive.throttling.actors.ClientRequest
-import spray.http.HttpResponse
-import com.pragmasoft.reactive.throttling.threshold.Frequency
-import com.pragmasoft.reactive.throttling.http.DiscardedClientRequest
+import com.pragmasoft.reactive.throttling.actors.{ClientRequest, _}
+import com.pragmasoft.reactive.throttling.actors.handlerspool.{FixedSizePool, HandlerFactory, OneActorPerRequestPool}
 import com.pragmasoft.reactive.throttling.http.HttpThrottlingConfiguration
+import com.pragmasoft.reactive.throttling.threshold.Frequency
+import spray.http.{HttpRequest, HttpResponse, _}
+
+import scala.concurrent.duration._
 
 
 object HttpServerRequestReplyHandler {
@@ -42,6 +25,7 @@ class HttpServerRequestReplyHandler(coordinator: ActorRef) extends RequestReplyH
   override def validateResponse(response: Any): ReplyHandlingStrategy = response match {
     case _: HttpResponse => COMPLETE
     case Confirmed(ChunkedResponseStart(_), _) => WAIT_FOR_MORE
+    case f: Status.Failure => FAIL(f)
     case _ => FAIL("Accepting only HttpResponse or Start notification for ChunkedResponse")
   }
 

--- a/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/actors/RequestReplyHandlerSpec.scala
+++ b/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/actors/RequestReplyHandlerSpec.scala
@@ -1,5 +1,6 @@
 package com.pragmasoft.reactive.throttling.actors
 
+import akka.actor.Status.Failure
 import akka.actor.{Props, ActorRef, ActorSystem}
 import akka.testkit.{TestProbe, ImplicitSender, TestKit}
 import com.pragmasoft.reactive.throttling.util.RetryExamples
@@ -85,7 +86,7 @@ class RequestReplyHandlerSpec extends Specification with NoTimeConversions with 
       transport expectMsg "request"
       transport reply 100
 
-      client.expectNoMsg()
+      client expectMsgClass classOf[Failure]
     }
 
     "not fail for replies of type Int" in new ActorTestScope(system) {
@@ -103,7 +104,7 @@ class RequestReplyHandlerSpec extends Specification with NoTimeConversions with 
       transport expectMsg "request"
       transport reply 100
 
-      client.expectNoMsg()
+      client expectMsgClass classOf[Failure]
       handlerDeathWatch.expectNoMsg()
     }
 

--- a/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/actors/SimpleRequestReplyHandlerSpec.scala
+++ b/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/actors/SimpleRequestReplyHandlerSpec.scala
@@ -1,5 +1,6 @@
 package com.pragmasoft.reactive.throttling.actors
 
+import akka.actor.Status.Failure
 import akka.testkit.{TestProbe, ImplicitSender, TestKit}
 import akka.actor.{ActorRef, Props, ActorSystem}
 import scala.concurrent.duration._
@@ -61,6 +62,7 @@ class SimpleRequestReplyHandlerSpec extends Specification with NoTimeConversions
     }
 
     "ignore replies of wrong type" in new ActorTestScope(system) {
+
       val transport = TestProbe()
       val coordinator = TestProbe()
       val client = TestProbe()
@@ -71,7 +73,7 @@ class SimpleRequestReplyHandlerSpec extends Specification with NoTimeConversions
       transport.expectMsg("request")
       transport.reply(handler, 100)
 
-      client.expectNoMsg()
+      client expectMsgClass classOf[Failure]
     }
 
     "not fail for replies of wrong type" in new ActorTestScope(system) {
@@ -89,7 +91,7 @@ class SimpleRequestReplyHandlerSpec extends Specification with NoTimeConversions
       transport.expectMsg("request")
       transport.reply(handler, 100)
 
-      client.expectNoMsg()
+      client expectMsgClass classOf[Failure]
       handlerDeathWatch.expectNoMsg()
     }
 

--- a/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/http/client/SimpleSprayClientSpec.scala
+++ b/spray-funnel/src/test/scala/com/pragmasoft/reactive/throttling/http/client/SimpleSprayClientSpec.scala
@@ -1,8 +1,10 @@
 package com.pragmasoft.reactive.throttling.http.client
 
 import akka.actor.ActorSystem
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import com.pragmasoft.reactive.throttling.threshold._
+import org.specs2.matcher.{MustThrownExpectations, FutureMatchers}
+import spray.can.Http.RequestTimeoutException
 import scala.concurrent.Future
 import akka.util.Timeout
 import scala.concurrent.duration._
@@ -42,11 +44,13 @@ class SimpleClient(serviceAddress: String, frequency: Frequency, parallelRequest
 
 
 class SimpleSprayClientSpec extends Specification with NoTimeConversions with RetryExamples {
+
   val MAX_FREQUENCY: Frequency = 5 every (15 seconds)
   val MAX_PARALLEL_REQUESTS = 3
   val TIMEOUT: Timeout = MAX_FREQUENCY.interval * 3
 
-  val testConf = ConfigFactory.parseString("""
+  val defaultTestConf = ConfigFactory.parseString(
+    """
     spray.can {
       host-connector {
         max-redirects = 5
@@ -61,7 +65,25 @@ class SimpleSprayClientSpec extends Specification with NoTimeConversions with Re
     }
     """)
 
+  val fastTimeoutNoRetryTestConf = ConfigFactory.parseString(
+    """
+    spray.can {
+      client {
+        request-timeout = 2 s
+      }
+      host-connector {
+        max-redirects = 5
+        max-retries = 0
+      }
+      server.remote-address-header = on
+    }
 
+    akka {
+      log-dead-letters-during-shutdown = off
+      loglevel = ERROR
+      loggers = ["akka.event.slf4j.Slf4jLogger"]
+    }
+    """)
 
   "A Spray Client throtteling the sendReceive pipeline" should {
     s"Enqueue requests to do maximum $MAX_FREQUENCY" in new WithStubbedApi {
@@ -93,20 +115,30 @@ class SimpleSprayClientSpec extends Specification with NoTimeConversions with Re
 
     "Have no concurrent request threshold for unbounded channels" in new WithStubbedApi(responseDelay = MAX_FREQUENCY.interval) {
       val totalRequests = MAX_PARALLEL_REQUESTS + 1
-      for {id <- 1 to totalRequests} yield { client.callFakeService(id) }
+      for {id <- 1 to totalRequests} yield {
+        client.callFakeService(id)
+      }
 
       withinTimeout(1 second) {
         val requests = requestList(TIMEOUT)
         requests.length shouldEqual totalRequests
       }
     }
+
+    "Complete future when spray client times out" in new WithStubbedApi(responseDelay = 1000 seconds, fastTimeoutNoRetryTestConf) with FutureMatchers with MustThrownExpectations {
+
+      val er = client.callFakeServiceWithMaxParallelRequests(1)
+
+      er must throwA[RequestTimeoutException].await(0, 100 seconds)
+    }
   }
 
 
   import com.pragmasoft.reactive.throttling.util.stubserver._
 
-  class WithStubbedApi(val responseDelay: FiniteDuration = 0 seconds) extends Around with StubServerSupport {
-    override lazy val context = ActorSystem(Utils.actorSystemNameFrom(getClass), testConf)
+  class WithStubbedApi(val responseDelay: FiniteDuration = 0 seconds, conf: Config = defaultTestConf) extends Around with StubServerSupport {
+
+    override lazy val context = ActorSystem(Utils.actorSystemNameFrom(getClass), conf)
 
     var client: SimpleClient = _
 


### PR DESCRIPTION
e.g. request timeout to downstream client, otherwise Futures created by spray pipeline never complete